### PR TITLE
refactor: remove get context history

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,10 +258,6 @@ async def main() -> None:
     thread = await liminal.thread.create(model_instance.id, "New Thread")
     # >>> Thread(...)
 
-    # Get the "de-identified" (containing sensitive data) context history for a thread:
-    thread = await liminal.thread.get_deidentified_context_history(model_instance.id)
-    # >>> [DeidentifiedToken(...), DeidentifiedToken(...), DeidentifiedToken(...)]
-
 
 asyncio.run(main())
 ```

--- a/liminal/endpoints/thread/__init__.py
+++ b/liminal/endpoints/thread/__init__.py
@@ -8,7 +8,7 @@ from typing import cast
 from httpx import Response
 
 from liminal.const import SOURCE
-from liminal.endpoints.thread.models import DeidentifiedToken, Thread
+from liminal.endpoints.thread.models import Thread
 from liminal.helpers.typing import ValidatedResponseT
 
 
@@ -86,28 +86,5 @@ class ThreadEndpoint:
             Thread,
             await self._request_and_validate(
                 "GET", f"/api/v1/threads/{thread_id}", Thread
-            ),
-        )
-
-    async def get_deidentified_context_history(
-        self, thread_id: int
-    ) -> list[DeidentifiedToken]:
-        """Get the deidentified context history for a thread.
-
-        Args:
-            thread_id: The ID of the thread.
-
-        Returns:
-            A list of DeidentifiedToken objects representing the deidentified context
-                history.
-
-        """
-        return cast(
-            list[DeidentifiedToken],
-            await self._request_and_validate(
-                "POST",
-                "/api/v1/sdk/get_context_history",
-                list[DeidentifiedToken],
-                json={"threadId": thread_id},
             ),
         )

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -87,27 +87,3 @@ async def test_get_by_id(
 
     thread = await mock_client.thread.get_by_id(161)
     assert thread.name == "My thread"
-
-
-@pytest.mark.asyncio()
-async def test_get_deidentified_context_history(
-    httpx_mock: HTTPXMock,
-    mock_client: Client,
-    threads_get_deidentified_context_history_response: dict[str, Any],
-) -> None:
-    """Test the get available threads method.
-
-    Args:
-        httpx_mock: The HTTPX mock fixture.
-        mock_client: A mock Liminal client.
-        threads_get_deidentified_context_history_response: The response from the endpoint.
-
-    """
-    httpx_mock.add_response(
-        method="POST",
-        url=f"{TEST_API_SERVER_URL}/api/v1/sdk/get_context_history",
-        json=threads_get_deidentified_context_history_response,
-    )
-
-    tokens = await mock_client.thread.get_deidentified_context_history(161)
-    assert len(tokens) == 9


### PR DESCRIPTION
## Breaking Change

<!-- Breaking changes should be called out early on. -->
<!-- Add specific instructions to help users who upgrade. Delete this section if appropriate. -->

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

- Removes `thread.get_deidentified_context_history`
- This function is using the last remaining `/sdk` endpoint, which this PR is proposing that we might not need. There is no clear use case (that I'm aware of) for this function; if something like this is needed in the future I'd rather just re-add it properly at that time and forego needing to maintain it in the meantime
- If there is a known use case for it, I'm happy to close this 😄 

[ssia]: https://en.wiktionary.org/wiki/SSIA

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

N/A

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for my changes (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there were no visible errors.

[best_practices]: https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
