### PR TITLE
fix: ensure incomplete streaming chunks are properly handled

### DIFF
--- a/liminal/client.py
+++ b/liminal/client.py
@@ -226,7 +226,7 @@ class Client:
         cookies: dict[str, str] | None = None,
         params: dict[str, str] | None = None,
         json: dict[str, Any] | None = None,
-    ) -> AsyncIterator[bytes]:
+    ) -> AsyncIterator[str]:
         """Make a request to the Liminal API server and return a streaming response.
 
         Args:
@@ -256,7 +256,9 @@ class Client:
             json=json,
         ) as resp:
             async for chunk in resp.aiter_bytes():
-                yield chunk
+                decoded_chunk = chunk.decode()
+                LOGGER.info("Received chunk of streaming response: %s", decoded_chunk)
+                yield decoded_chunk
 
     def add_session_id_callback(
         self, callback: Callable[[str], None]

--- a/liminal/client.py
+++ b/liminal/client.py
@@ -255,10 +255,9 @@ class Client:
             params=params,
             json=json,
         ) as resp:
-            async for chunk in resp.aiter_bytes():
-                decoded_chunk = chunk.decode()
-                LOGGER.info("Received chunk of streaming response: %s", decoded_chunk)
-                yield decoded_chunk
+            async for line in resp.aiter_lines():
+                LOGGER.info("Received line of streaming response: %s", line)
+                yield line
 
     def add_session_id_callback(
         self, callback: Callable[[str], None]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,7 +267,7 @@ def prompt_stream_response_iterator_fixture(
             raw_chunk["finishReason"] = None
         else:
             raw_chunk["finishReason"] = "stop"
-        output.append(json.dumps(raw_chunk).encode())
+        output.append(f"{json.dumps(raw_chunk)}\n".encode())
     return IteratorStream(output)
 
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -9,6 +9,7 @@ import pytest
 from pytest_httpx import HTTPXMock, IteratorStream
 
 from liminal import Client
+from liminal.endpoints.prompt.models import StreamResponseChunk
 from tests.common import TEST_API_SERVER_URL
 
 
@@ -241,10 +242,11 @@ async def test_stream_incomplete_chunk(
         thread_id=123,
     )
 
-    # Walk through the stream purely to ensure a log is generated when an incomplete
-    # chunk is received:
-    async for _ in response:
-        pass
+    # Walk through the stream to ensure (a) that each chunk is properly parsed as a
+    # StreamResponseChunk object and (b) we properly log an error when the incomplete
+    # chunk is detected:
+    async for chunk in response:
+        assert isinstance(chunk, StreamResponseChunk)
     assert any(
         m for m in caplog.messages if "Stream returned incomplete JSON chunk" in m
     )


### PR DESCRIPTION
## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Every so often, the Liminal API server will return an incomplete chunk in a streaming response (specifically, a chunk that has not been fully JSON-encoded in the API server's output schema). This has been tricky to nail down; it seems to only happen with specific models, but even then, we might see hundreds of successful requests without this behavior.

This PR does two things to mitigate this:

* Instead of interpreting each chunk as a series of bytes, we rely on the fact that the Liminal API server returns newline-delimited JSON strings and specifically parses each chunk as that construct.
* We also add an exception handler whereupon any incomplete JSON string chunk will log a warning but still be returned as part of a `StreamResponseChunk` object.

[ssia]: https://en.wiktionary.org/wiki/SSIA

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

N/A

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for my changes (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there were no visible errors.

[best_practices]: https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
