### PR TITLE
refactor!: remove strict validation of model providers

### DIFF
--- a/liminal/endpoints/llm/models.py
+++ b/liminal/endpoints/llm/models.py
@@ -4,34 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
 
 from mashumaro import field_options
 
 from liminal.helpers.model import BaseModel
-
-
-# Define enums to use as types:
-class ModelProviderKey(str, Enum):
-    """Define the enum for the model provider key."""
-
-    ANTHROPIC = "anthropic"
-    AWS_BEDROCK = "aws_bedrock"
-    AWS_SAGEMAKER = "aws_sagemaker"
-    AZURE_OPENAI = "azure_openai"
-    COHERE = "cohere"
-    COPILOT_STUDIO = "copilot_studio"
-    DEEPSEEK = "deepseek"
-    GOOGLE_AI_STUDIO = "google_ai_studio"
-    GOOGLE_VERTEX_AI = "google_vertex_ai"
-    GROQ = "groq"
-    HUGGINGFACE = "huggingface"
-    IBM_WATSONX = "ibm_watsonx"
-    MISTRAL = "mistral"
-    OLLAMA = "ollama"
-    OPENAI = "openai"
-    PERPLEXITY = "perplexity"
-    XAI = "xai"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -46,7 +22,7 @@ class ModelConnection(BaseModel):
     # Fields:
     credentials: dict[str, str] | None = field(default_factory=dict)
     model: str
-    provider_key: ModelProviderKey = field(metadata=field_options(alias="providerKey"))
+    provider_key: str = field(metadata=field_options(alias="providerKey"))
 
     # Timestamps:
     created_at: datetime = field(metadata=field_options(alias="createdAt"))


### PR DESCRIPTION
## Breaking Change

The `ModelInstance` object returned by `liminal.llm.get_available_model_instances()` would previously use a `ModelProviderKey` enum for its `provider_key` field. That field now returns a string with the actual provider key (e.g., `"openai"`).

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

- We were previously strictly validating supported model provider keys.
- As the Liminal platform adds new providers, it's too easy to forget to add them to the SDK's strict validation (which, then, would cause unhandled exceptions).
- Since the Liminal API will never return "unexpected" provider keys, let's relax the validation here to future-proof the SDK a bit.
- Users of the SDK can, of course, add their own validation.

[ssia]: https://en.wiktionary.org/wiki/SSIA

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

N/A

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`development`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for my changes (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there were no visible errors.

[best_practices]: https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
